### PR TITLE
Fix Ruby 1.9 compatibility

### DIFF
--- a/lib/teapot.rb
+++ b/lib/teapot.rb
@@ -11,7 +11,7 @@ class Teapot
   end
   def call(env) #:nodoc:
     if env["REQUEST_METHOD"] == "BREW" || env["Content-Type"] == "application/coffee-pot-command"
-      ["418 I'm a teapot", {}, "Care for a cup of #{@tea}?"]
+      ["418 I'm a teapot", {}, ["Care for a cup of #{@tea}?"]]
     else
       @app.call(env)
     end


### PR DESCRIPTION
From [the latest Rack spec](https://github.com/rack/rack/blob/2.0.3/SPEC#L244):

> The Body must respond to each and must only yield String values. The Body itself should not be an instance of String, as this will break in Ruby 1.9.

Wrapping in an array should work!

Side-note: to run the tests on ruby 2.4 requires a `gem install test-unit-minitest`