### PR TITLE
Mention Content-Type header in Teapot comment

### DIFF
--- a/lib/teapot.rb
+++ b/lib/teapot.rb
@@ -1,4 +1,4 @@
-# Rack middleware to respond to BREW and coffee-pot-command requests. Use in a rackup file like so:
+# Rack middleware to respond to BREW requests or requests with Content-Type `application/coffee-pot-command`. Use in a rackup file like so:
 #
 #   use Teapot
 #


### PR DESCRIPTION
## Summary
- clarify top comment about handling BREW requests or `application/coffee-pot-command` content type

## Testing
- `(cd test && ruby test_teapot.rb)`

------
https://chatgpt.com/codex/tasks/task_e_68abaef7f628832f86ca0ee68dfcf934