### PR TITLE
Modernize Ruby setup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'rake/testtask'
-require 'rake/rdoctask'
-require 'rake/gempackagetask'
+require 'rdoc/task'
+require 'rubygems/package_task'
 
 task :default => [:test]
 
@@ -10,15 +10,15 @@ Rake::TestTask.new { |t|
   t.warning = true
 }
 
-Rake::RDocTask.new do |rd|
+RDoc::Task.new do |rd|
   rd.main = "Readme.rdoc"
   rd.rdoc_files.include("Readme.rdoc", "lib/*.rb", "License", "Changelog.rdoc")
   rd.rdoc_dir = "doc"
 end
 
-load File.join(File.dirname(__FILE__), "teapot.gemspec")
+spec = Gem::Specification.load('teapot.gemspec')
 
-Rake::GemPackageTask.new(TEAPOT_GEM_SPEC) do |package|
+Gem::PackageTask.new(spec) do |package|
   package.need_zip = true
   package.need_tar = true
 end

--- a/Readme.rdoc
+++ b/Readme.rdoc
@@ -6,13 +6,12 @@ For more information see http://www.ietf.org/rfc/rfc2324.txt
 
 == INSTALL
 
-  sudo gem install toolmantim-teapot --source http://gems.github.com
+  gem install teapot
 
 == USAGE
 
 Simply <tt>require</tt> and <tt>use</tt> from your rackup file (e.g. <tt>config.ru</tt>):
 
-  require 'rubygems'
   require 'teapot'
 
   use Teapot

--- a/lib/teapot.rb
+++ b/lib/teapot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Rack middleware to respond to BREW and coffee-pot-command requests. Use in a rackup file like so:
 #
 #   use Teapot
@@ -6,7 +8,7 @@
 #
 #   use Teapot, "Lady Grey"
 class Teapot
-  def initialize(app, tea="English Breakfast") #:nodoc:
+  def initialize(app, tea = "English Breakfast") #:nodoc:
     @app, @tea = app, tea
   end
   def call(env) #:nodoc:

--- a/teapot.gemspec
+++ b/teapot.gemspec
@@ -1,18 +1,21 @@
-TEAPOT_GEM_SPEC = Gem::Specification.new do |s|
-  s.name     = "teapot"
-  s.version  = "1.0.1"
-  s.date     = "2009-01-15"
-  s.summary  = s.description = "Rack middleware to help you, as a teapot, comply with HTCPCP/1.0: the Hyper Text Coffee Pot Control Protocol"
-  s.email    = "t.lucas@toolmantim.com"
-  s.homepage = "http://github.com/toolmantim/teapot"
-  s.has_rdoc = true
-  s.authors  = ["Tim Lucas"]
-  s.files    = ["Changelog.rdoc",
-                "License",
-                "Readme.rdoc",
-                "teapot.gemspec",
-                "lib/teapot.rb",
-                "test/test_teapot.rb"]
-  s.rdoc_options = ["--main", "Readme.rdoc"]
-  s.extra_rdoc_files = ["Changelog.rdoc", "Readme.rdoc"]
+Gem::Specification.new do |spec|
+  spec.name          = "teapot"
+  spec.version       = "1.0.1"
+  spec.summary       = "Rack middleware to help you, as a teapot, comply with HTCPCP/1.0: the Hyper Text Coffee Pot Control Protocol"
+  spec.description   = spec.summary
+  spec.authors       = ["Tim Lucas"]
+  spec.email         = ["t.lucas@toolmantim.com"]
+  spec.homepage      = "http://github.com/toolmantim/teapot"
+  spec.license       = "WTFPL"
+  spec.required_ruby_version = ">= 3.0"
+  spec.files         = [
+    "Changelog.rdoc",
+    "License",
+    "Readme.rdoc",
+    "teapot.gemspec",
+    "lib/teapot.rb",
+    "test/test_teapot.rb"
+  ]
+  spec.require_paths = ["lib"]
 end
+

--- a/test/test_teapot.rb
+++ b/test/test_teapot.rb
@@ -1,9 +1,7 @@
-require 'test/unit'
-
-require 'rubygems'
+require 'minitest/autorun'
 require 'rack/mock'
 
-require File.join(File.dirname(__FILE__), "..", "lib", "teapot")
+require_relative '../lib/teapot'
 
 class DummyApp
   def call(env)
@@ -11,7 +9,7 @@ class DummyApp
   end
 end
 
-class TeapotTest < Test::Unit::TestCase
+class TeapotTest < Minitest::Test
   def test_returns_418_with_content_type_coffee_pot_command
     req = Rack::MockRequest.new(Teapot.new(DummyApp.new, "English Breakfast"))
     res = req.get("", {"Content-Type" => "application/coffee-pot-command"})


### PR DESCRIPTION
## Summary
- replace deprecated Rake tasks with modern equivalents
- adopt minitest and require_relative in tests
- update gemspec, documentation, and source for current Ruby practices

## Testing
- `ruby -Ilib test/test_teapot.rb`
- `rake test`


------
https://chatgpt.com/codex/tasks/task_e_68abae899724832fad304f4aa72a599c